### PR TITLE
Add note on known issue in ERA5 May-Oct 1996

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
++ Note on known issue in ERA5 May-Oct 1996 which affects the Amundsen Sea.
+
 ## 0.2.6 - 2026-05-21
 
 ### Fixed

--- a/src/asli/templates/asli_data.csv.template
+++ b/src/asli/templates/asli_data.csv.template
@@ -31,4 +31,5 @@
 # [a]: Area-average sea level pressure over sector
 # [b]: Relative central pressure (actual_central_pressure 'minus' sector_pressure)
 # [c]: ERA5 (final data) or ERA5T (initial release data) from ECMWF
-time (mo),longitude (degree),latitude (degree),actual_central_pressure (hPa),sector_pressure (hPa) [a],relative_central_pressure (hPa) [b],data_source [c]
+# [d]: There is a known ERA5 issue which affects pressure values and ASL location for May - October 1996. For details please consult https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation#ERA5:datadocumentation-Knownissues number 30.
+time (mo),longitude (degree),latitude (degree),actual_central_pressure (hPa),sector_pressure (hPa) [a],relative_central_pressure (hPa) [b],data_source [c] [d]


### PR DESCRIPTION
ECMWF have finally added a known issue here: https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation#ERA5:datadocumentation-Knownissues

On the misattributed station altitude for May-Oct 1996 which affects the effective sea level pressure, resulting in issues for calculating the ASLI for this time period.