### PR TITLE
Add line plots for calculated ASLI values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
++ Line plots for calculated ASLI values in the Python API and CLI.
+
 ## 0.2.7 - 2026-05-28
 
 ### Added

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -90,3 +90,17 @@ asli plot --input asli_1959-2026.csv --output asli_1959-2026.png --year 2025 --m
 With the output file:
 
 ![](../assets/images/asli_plot_Apr2025.png)
+
+To plot calculated ASLI values such as central pressure, longitude, and latitude
+as line plots, add `--line`. By default this includes `ActCenPres`, `SectPres`,
+`RelCenPres`, `longitude`, and `latitude`.
+
+```sh
+asli plot --line --input asli_1959-2026.csv --output asli_1959-2026_lines.png ./data/era5/monthly/era5_mean_sea_level_pressure_monthly_1959-2026.nc
+```
+
+Use repeated `--line-column` options to choose specific values:
+
+```sh
+asli plot --line --line-column ActCenPres --line-column Lat --input asli_1959-2026.csv --output asli_1959-2026_pressure_lat.png ./data/era5/monthly/era5_mean_sea_level_pressure_monthly_1959-2026.nc
+```

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -130,6 +130,16 @@ These methods all return a `matplotlib` figure object.
 
 Additional arguments can be passed to all of these commands to control the plotting, for full details see `plot_month` in the [API reference](../../autoapi/asli/plot#asli.plot.Plotter.plot_month).
 
+Calculated ASLI values can also be plotted as time-series lines:
+
+```py
+fig, ax = plotter.plot_line(column="ActCenPres")
+fig, axes = plotter.plot_lines(columns=["ActCenPres", "Long", "Lat"])
+```
+
+The default `plot_lines()` output includes `ActCenPres`, `SectPres`,
+`RelCenPres`, `longitude`, and `latitude`.
+
 ## Working with Zarr and Object Storage
 The `asli` package also supports Zarr data import from s3 storage through the python interface. The method remains the same, but you will need to install the [s3] optional dependencies.
 

--- a/src/asli/cli.py
+++ b/src/asli/cli.py
@@ -64,7 +64,10 @@ def _cli_plot(args):
 
     # Plot all if no specific year is provided
     plotter = Plotter(a)
-    if args.month and args.year:
+    if args.line:
+        logger.info(f"Plotting ASLI line plots from {args.msl_files}.")
+        fig, _ = plotter.plot_lines(columns=args.line_columns)
+    elif args.month and args.year:
         logger.info(f"Plotting for {args.year}-{args.month} from {args.msl_files}.")
         fig, _ = plotter.plot_month(year=args.year, month=args.month, colorbar=True)
     elif args.year:
@@ -330,6 +333,17 @@ def _top_level_parser() -> argparse.ArgumentParser:
         nargs="?",
         type=_validate_month,
         help="When present, plot only the month specified. Requires --year to be present.",
+    )
+    plot_parser.add_argument(
+        "--line",
+        action="store_true",
+        help="Plot calculated ASLI values as time-series lines instead of pressure maps.",
+    )
+    plot_parser.add_argument(
+        "--line-column",
+        dest="line_columns",
+        action="append",
+        help="Column or alias to include with --line. May be repeated.",
     )
 
     return parser

--- a/src/asli/plot.py
+++ b/src/asli/plot.py
@@ -13,6 +13,29 @@ from .asli import ASLICalculator
 from .params import ASL_REGION
 
 
+LINE_PLOT_COLUMNS = ("ActCenPres", "SectPres", "RelCenPres", "longitude", "latitude")
+LINE_PLOT_ALIASES = {
+    "actcenpres": "ActCenPres",
+    "actual_central_pressure": "ActCenPres",
+    "sectpres": "SectPres",
+    "sector_pressure": "SectPres",
+    "relcenpres": "RelCenPres",
+    "relative_central_pressure": "RelCenPres",
+    "lon": "longitude",
+    "long": "longitude",
+    "longitude": "longitude",
+    "lat": "latitude",
+    "latitude": "latitude",
+}
+LINE_PLOT_LABELS = {
+    "ActCenPres": "Actual central pressure (hPa)",
+    "SectPres": "Sector pressure (hPa)",
+    "RelCenPres": "Relative central pressure (hPa)",
+    "longitude": "Longitude (degrees east)",
+    "latitude": "Latitude (degrees north)",
+}
+
+
 class Plotter:
     def __init__(
         self,
@@ -192,6 +215,104 @@ class Plotter:
             self.draw_regional_box(ax, regionbox)
 
         return fig, ax
+
+    def _line_plot_column(self, column: str) -> str:
+        """Resolve line plot column names and common aliases."""
+
+        resolved = LINE_PLOT_ALIASES.get(column.lower(), column)
+        if resolved not in self.df.columns:
+            valid = ", ".join(LINE_PLOT_COLUMNS)
+            raise ValueError(f"Column {column!r} not found. Expected one of: {valid}.")
+        return resolved
+
+    def plot_line(
+        self,
+        column: str = "ActCenPres",
+        ax: matplotlib.axes.Axes = None,
+        width: float = 10,
+        height: float = 4,
+        marker: str = "o",
+        color: str = None,
+    ):
+        """
+        Plot one calculated ASLI value as a time-series line plot.
+
+        Args:
+            column (str): Data column or alias to plot. Common choices are
+                ActCenPres, SectPres, RelCenPres, longitude, and latitude.
+            ax (matplotlib.axes.Axes, optional): axes object to use for plot.
+            width (float, optional): figure width when ax is not supplied.
+            height (float, optional): figure height when ax is not supplied.
+            marker (str, optional): matplotlib marker style.
+            color (str, optional): matplotlib line color.
+
+        Returns:
+            fig (matplotlib.figure.Figure): figure object
+            ax (matplotlib.axes.Axes): axis object
+        """
+
+        column = self._line_plot_column(column)
+        plot_df = self.df.copy()
+        plot_df["time"] = pd.to_datetime(plot_df["time"])
+        plot_df.sort_values("time", inplace=True)
+
+        if ax is None:
+            fig = matplotlib.figure.Figure(figsize=(width, height))
+            ax = fig.add_subplot()
+        else:
+            fig = ax.get_figure()
+
+        plot_kwargs = {"marker": marker}
+        if color is not None:
+            plot_kwargs["color"] = color
+        ax.plot(plot_df["time"], plot_df[column], **plot_kwargs)
+        ax.set_xlabel("Time")
+        ax.set_ylabel(LINE_PLOT_LABELS.get(column, column))
+        ax.set_title(LINE_PLOT_LABELS.get(column, column))
+        fig.autofmt_xdate()
+
+        return fig, ax
+
+    def plot_lines(
+        self,
+        columns: list[str] = None,
+        n_cols: int = 1,
+        width: float = None,
+        height: float = None,
+        marker: str = "o",
+    ):
+        """
+        Plot multiple calculated ASLI values as stacked time-series line plots.
+
+        Args:
+            columns (list[str], optional): Data columns or aliases to plot.
+                Defaults to ActCenPres, SectPres, RelCenPres, longitude, and latitude.
+            n_cols (int, optional): Number of subplot columns. Defaults to 1.
+            width (float, optional): Figure width. Defaults from n_cols.
+            height (float, optional): Figure height. Defaults from row count.
+            marker (str, optional): matplotlib marker style.
+
+        Returns:
+            fig (matplotlib.figure.Figure): figure object
+            axes (list[matplotlib.axes.Axes]): line plot axes
+        """
+
+        columns = list(columns) if columns is not None else list(LINE_PLOT_COLUMNS)
+        columns = [self._line_plot_column(column) for column in columns]
+        n_rows = math.ceil(len(columns) / n_cols)
+        fig = matplotlib.figure.Figure(
+            figsize=(width or n_cols * 10, height or n_rows * 3)
+        )
+
+        axes = []
+        for i, column in enumerate(columns):
+            ax = fig.add_subplot(n_rows, n_cols, i + 1)
+            self.plot_line(column=column, ax=ax, marker=marker)
+            axes.append(ax)
+
+        fig.tight_layout()
+
+        return fig, axes
 
     def plot_da(self, da: xr.DataArray, n_cols: int = 3, *args, **kwargs):
         """Plot all the months in the given DataArray, da.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,7 @@ class TestCliPlot(unittest.TestCase):
     def setUp(self):
         self.lsm_file = str(Path("tests", "fixtures", "test_lsm.nc"))
         self.msl_file = str(Path("tests", "fixtures", "test_era5_msl.nc"))
+        self.csv_file = str(Path("tests", "fixtures", "test_csv.csv"))
 
     def tearDown(self):
         pass
@@ -94,6 +95,26 @@ class TestCliPlot(unittest.TestCase):
                 "2024",
                 "--month",
                 "4",
+                "--mask",
+                self.lsm_file,
+                self.msl_file,
+            ],
+        ):
+            cli()
+
+    def test_cli_plot_lines(self):
+        with patch(
+            "sys.argv",
+            [
+                "_",
+                "plot",
+                "--line",
+                "--line-column",
+                "ActCenPres",
+                "--line-column",
+                "Lat",
+                "--input",
+                self.csv_file,
                 "--mask",
                 self.lsm_file,
                 self.msl_file,

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -41,3 +41,17 @@ class TestPlotting(unittest.TestCase):
 
         assert isinstance(fig, matplotlib.figure.Figure)
         assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_plot_line(self):
+        fig, ax = self.plotter.plot_line(column="ActCenPres")
+
+        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(ax, matplotlib.axes.Axes)
+        assert ax.get_ylabel() == "Actual central pressure (hPa)"
+
+    def test_plot_lines(self):
+        fig, axes = self.plotter.plot_lines(columns=["ActCenPres", "Long", "Lat"])
+
+        assert isinstance(fig, matplotlib.figure.Figure)
+        assert len(axes) == 3
+        assert all(isinstance(ax, matplotlib.axes.Axes) for ax in axes)


### PR DESCRIPTION
## Summary
- add `Plotter.plot_line()` and `Plotter.plot_lines()` for time-series plots of calculated ASLI values
- add `asli plot --line` and repeatable `--line-column` options for CLI use
- document CLI and Python examples, and record the change in the changelog

Fixes #10

## Validation
- `.venv/bin/python -m pytest tests/test_plot.py tests/test_cli.py -q` - 11 passed, 1 warning
- `.venv/bin/python -m pytest -q` - 18 passed, 3 warnings
- `.venv/bin/ruff check src`
- `.venv/bin/python -m py_compile src/asli/plot.py src/asli/cli.py tests/test_plot.py tests/test_cli.py`
- `git diff --check`

Warnings were from dependency imports/CDS certificate checks during existing tests; they did not fail the suite.